### PR TITLE
Check no_lynch against player values

### DIFF
--- a/vote_count.py
+++ b/vote_count.py
@@ -21,9 +21,8 @@ class  VoteCount:
         # Load vote rights table
         self.vote_rights = pd.read_csv('vote_config.csv', sep=',')
 
-
         ## Check if no_lynch row is present. Add it if missing, but keep it disabled.
-        if 'no_lynch' not in self.vote_rights['player']:
+        if 'no_lynch' not in self.vote_rights['player'].values:
             self.vote_rights.loc[len(self.vote_rights),:] = ['no_lynch',0,0,0]
         
         # use lowercase player names as keys, player column as true names


### PR DESCRIPTION
Previously, to check if no_lynch was on the vote_rights, we tested whether no_lynch was in the player columns. Not sure why, it was always returning False, and thus, no_lynch appended no matter If it was already present on vote_config.csv. This check has been fixed by comparing against the column values, which is a list.

Closes #24 