### PR TITLE
Fix persistent majority reached flag

### DIFF
--- a/main.py
+++ b/main.py
@@ -84,7 +84,10 @@ def run(update_tick: int):
 
             last_votecount_id = last_votecount[0]
             majority_reached  = last_votecount[1]
-            
+
+            if last_votecount_id < current_day_start_post and majority_reached:
+                majority_reached = False            
+
             if not majority_reached:
 
                 last_thread_post  = tr.get_last_post(game_thread=settings.game_thread)


### PR DESCRIPTION
If the previous day ends by a player reaching absolute majority, the flag will not be reset upon a new day, and thus, no new votes will be counted (nor any game action).

This fix checks If the last vote count ID is older than the day start post and If the majority_reached flag is set to True. In this case,  it sets it back to False.

Closes #29 