### PR TITLE
Add a command to set up a lylo

### DIFF
--- a/main.py
+++ b/main.py
@@ -180,11 +180,16 @@ def resolve_action_queue(queue: list, vcount: vote_count.VoteCount, last_count:i
                                     victim=game_action.victim,
                                     post_id=game_action.id)
 
-
             elif game_action.type == actions.Action.unvote:
                 vcount.unvote_player(action=game_action)
             
-            
+            elif game_action.type == actions.Action.lylo:
+
+                logging.info(f'{game_action.author} requested an vcount lock at  {game_action.post_id}')
+
+                if game_action.author in staff:
+                    vcount.lock_unvotes()
+
             elif game_action.type == actions.Action.replace_player and game_action.author in staff:
 
                 if game_action.actor in player_list:

--- a/modules/game_actions.py
+++ b/modules/game_actions.py
@@ -22,7 +22,8 @@ class GameAction:
                                    actions.Action.vote_history: self._request_vote_history,
                                    actions.Action.get_voters: self._request_voters_history,
                                    actions.Action.modkill: self._modkill,
-                                   actions.Action.freeze_vote: self._freeze_votes}
+                                   actions.Action.freeze_vote: self._freeze_votes,
+                                   actions.Action.lylo: self._set_lylo}
 
         # Parse command type
         self.type   = self._parse_expression(command=self._contents[0])
@@ -103,6 +104,8 @@ class GameAction:
     def _modkill(self, argument:list):
         self.victim = argument[-1]
     
+    def _set_lylo(self, argument:list):
+        self.target_post = self.id
     
     def _freeze_votes(self, argument:list):
 

--- a/states/action.py
+++ b/states/action.py
@@ -3,6 +3,7 @@ import enum
 class Action(enum.Enum):
     freeze_vote    = 'congelar'
     get_voters     = 'votantes'
+    lylo           = 'lylo'
     modkill        = 'modkill'
     request_count  = 'recuento'
     replace_player = 'reemplazo'

--- a/vote_count.py
+++ b/vote_count.py
@@ -35,6 +35,8 @@ class  VoteCount:
 
         # Frozen vote players
         self.frozen_players = list() 
+
+        self.locked_unvotes = False
         
 
     def player_exists(self, player:str) -> bool:
@@ -248,10 +250,14 @@ class  VoteCount:
         """
         self._is_valid_unvote = False
 
+        if self.locked_unvotes:
+            logging.info(f'Ignoring unvote casted by {player} due to LyLo.')
+            return self._is_valid_unvote
+
         # If the player votes are frozen then we have nothing to do here
         if player in self.frozen_players:
             return self._is_valid_unvote
-
+        
         if player in self._vote_table['voted_by'].values:
 
             if self.get_player_current_votes(player) >  0:
@@ -330,6 +336,16 @@ class  VoteCount:
                 logging.warning(f'Cannot freeze player {frozen_player}. Check vote_config.csv')
         else:
             logging.warning(f'Cannot freeze staff member {frozen_player}.')           
+
+
+    def lock_unvotes(self):
+        """
+        Lock the vote count, so that players will not be able to unvote for the
+        remaining of the day once a vote is casted. 
+        """
+        if not self.locked_unvotes:
+            self.locked_unvotes = True
+            logging.info('The vote count has been locked')
 
 
     #TODO: Awful function, fix it


### PR DESCRIPTION
LyLo is a situation where, in some games,
votes cannot be removed once casted. To allow
for such a behaviour, this commit adds a GM
command available for both the game master and
the moderators: lylo

Lylo sets a boolean to True in the vcount instance,
which in turns disables the unvote action by returning
False when is_valid_unvote is triggered.